### PR TITLE
New local context preserves logger

### DIFF
--- a/lib/backbeat.rb
+++ b/lib/backbeat.rb
@@ -46,6 +46,7 @@ module Backbeat
     def self.local
       config = new
       config.context = :local
+      config.logger = Backbeat.config.logger
       config
     end
 

--- a/spec/backbeat_spec.rb
+++ b/spec/backbeat_spec.rb
@@ -101,6 +101,16 @@ describe Backbeat do
       expect(Backbeat.config.store).to be_a(Backbeat::MemoryStore)
     end
 
+    it "defaults logger to configured logger when using local context" do
+      logger = Logger.new("/dev/null")
+      Backbeat.configure do |config|
+        config.logger = logger
+      end
+      local_context = Backbeat::Config.local
+
+      expect(local_context.logger).to be(logger)
+    end
+
     it "raises an error if the context is unknown" do
       Backbeat.configure do |config|
         config.context = :foo


### PR DESCRIPTION
Currently the way to force a workflow to run locally in some situation is to override the config with a new config instance coming from the factory `Backbeat::Config.local`. Unfortunately this defaults the logger to the NullLogger, thereby cutting off all logging, even if you have configured it for your app.

In order to be less upsetting, use the currently configured logger, if one exists.